### PR TITLE
Add default value to input mapping when storage.input.tables key missing

### DIFF
--- a/src/Keboola/DbWriter/Redshift/Application.php
+++ b/src/Keboola/DbWriter/Redshift/Application.php
@@ -32,7 +32,7 @@ class Application
         $this->container = new Container();
         $this->container['action'] = isset($config['action']) ? $config['action'] : 'run';
         $this->container['parameters'] = $parameters;
-        $this->container['inputMapping'] = $config['storage']['input']['tables'];
+        $this->container['inputMapping'] = $config['storage']['input']['tables'] ?? [];
         $this->container['logger'] = $logger;
         $this->container['writer'] = function ($container) {
             return new Redshift($container['parameters']['db'], $container['logger']);


### PR DESCRIPTION
Fixes #13 

For sync actions an error output is silenced. And due to missing key `storage`, this error won't be shown:

```
[2018-06-19 20:14:31] wr-db-redshift.ERROR: Undefined index: storage 
{"errFile":"/code/src/Keboola/DbWriter/Redshift/Application.php","errLine":35,"trace":
[{"file":"/code/src/Keboola/DbWriter/Redshift/Application.php","line":35,"function":"{closure}","args":
[8,"Undefined index: storage","/code/src/Keboola/DbWriter/Redshift/Application.php",35,{"config":
{"action":"testConnection","parameters":{"db":
{"host":"192.168.1.227","port":"5432","database":"test","user":"test","password":"test","schema":"test"},
"data_dir":"./data","writer_class":"Redshift"}},"logger":"[object] (Keboola\\DbWriter\\Logger: 
{})","configDefinition":"[object] (Keboola\\DbWriter\\Redshift\\Configuration\\ConfigDefinition: 
{})","validate":"[object] (Closure: {})","parameters":{"db":
{"host":"192.168.1.227","port":"5432","database":"test","user":"test","password":"test","schema":"test"},
"data_dir":"./data","writer_class":"Redshift","tables":[]}}]},
{"file":"/code/run.php","line":33,"function":"__construct","class":"Keboola\\DbWriter\\Redshift\\Application"
,"type":"->","args":[{"action":"testConnection","parameters":{"db":
{"host":"192.168.1.227","port":"5432","database":"test","user":"test","password":"test","schema":"test"},
"data_dir":"./data","writer_class":"Redshift"}},"[object] (Keboola\\DbWriter\\Logger: {})","[object] 
(Keboola\\DbWriter\\Redshift\\Configuration\\ConfigDefinition: {})"]}]} []
```

This PR will set default value for input mapping, so `Undefined index` error will be fixed and sync actions will be fixed.